### PR TITLE
Add Support for non-legacy animations 

### DIFF
--- a/Assets/Scripts/AnimationCaptureHelper.cs
+++ b/Assets/Scripts/AnimationCaptureHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using UnityEngine;
+using UnityEditor;
 
 /// <summary>
 /// A component used to help capture FBX animations into sprite sheets.
@@ -55,7 +56,7 @@ public class AnimationCaptureHelper : MonoBehaviour
         }
         else
         {
-            _sourceClip.SampleAnimation(_target, time);
+            AnimationMode.SampleAnimationClip(_target, _sourceClip, time);
         }
     }
 
@@ -69,6 +70,7 @@ public class AnimationCaptureHelper : MonoBehaviour
     /// </summary>
     public IEnumerator CaptureAnimation(Action<Texture2D, Texture2D> onComplete)
     {
+        AnimationMode.StartAnimationMode();
         if (_sourceClip == null || _target == null)
         {
             Debug.LogWarning("CaptureCamera should be set before capturing animation!");
@@ -146,6 +148,7 @@ public class AnimationCaptureHelper : MonoBehaviour
             _captureCamera.targetTexture = null;
             _captureCamera.backgroundColor = cachedCameraColor;
             DestroyImmediate(rtFrame);
+            AnimationMode.StopAnimationMode();
         }
     }
 

--- a/Assets/Scripts/Editor/AnimationCaptureHelperEditor.cs
+++ b/Assets/Scripts/Editor/AnimationCaptureHelperEditor.cs
@@ -15,11 +15,6 @@ public class AnimationCaptureHelperEditor : Editor
     private const string ASSIGN_REFS_INFO = "Assign the Target and SourceClip to start previewing!";
 
     /// <summary>
-    /// A message displayed when the assigned animation is not marked as legacy (required for SampleAnimation).
-    /// </summary>
-    private const string LEGACY_ANIM_WARN = "The SourceClip must be marked as Legacy!";
-
-    /// <summary>
     /// A message displayed when the capture camera isn't assigned yet.
     /// </summary>
     private const string ASSIGN_CAMERA_INFO = "Assign a camera to start capturing!";
@@ -52,11 +47,6 @@ public class AnimationCaptureHelperEditor : Editor
             }
 
             var sourceClip = (AnimationClip)sourceClipProp.objectReferenceValue;
-            if (!sourceClip.legacy)
-            {
-                EditorGUILayout.HelpBox(LEGACY_ANIM_WARN, MessageType.Warning);
-                return;
-            }
 
             using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
             {


### PR DESCRIPTION
Add Support for non-legacy animations by switching to AnimationMode.SampleAnimationClip. Generic and Humanoid captures will not respect the transform rotations on the game object, so you must use the camera positioning to alter the rotation of the captured sprite sheet.